### PR TITLE
[fix] reimplement language `Python` to override `expando_char`

### DIFF
--- a/crates/cli/src/languages/csharp.rs
+++ b/crates/cli/src/languages/csharp.rs
@@ -57,7 +57,7 @@ mod test {
   }
 
   #[test]
-  fn test_c_shapr_replace() {
+  fn test_c_sharp_replace() {
     let ret = test_replace("int @int = 0;", "int $A = 0;", "bool @bool = true");
     assert_eq!(ret, "bool @bool = true;");
   }

--- a/crates/cli/src/languages/mod.rs
+++ b/crates/cli/src/languages/mod.rs
@@ -11,7 +11,6 @@ use tree_sitter_html::language as language_html;
 use tree_sitter_javascript::language as language_javascript;
 use tree_sitter_kotlin::language as language_kotlin;
 use tree_sitter_lua::language as language_lua;
-// use tree_sitter_python::language as language_python;
 use tree_sitter_swift::language as language_swift;
 use tree_sitter_typescript::{language_tsx, language_typescript};
 

--- a/crates/cli/src/languages/mod.rs
+++ b/crates/cli/src/languages/mod.rs
@@ -1,4 +1,5 @@
 mod csharp;
+mod python;
 mod rust;
 use ignore::types::{Types, TypesBuilder};
 use std::borrow::Cow;
@@ -10,11 +11,12 @@ use tree_sitter_html::language as language_html;
 use tree_sitter_javascript::language as language_javascript;
 use tree_sitter_kotlin::language as language_kotlin;
 use tree_sitter_lua::language as language_lua;
-use tree_sitter_python::language as language_python;
+// use tree_sitter_python::language as language_python;
 use tree_sitter_swift::language as language_swift;
 use tree_sitter_typescript::{language_tsx, language_typescript};
 
 pub use csharp::CSharp;
+pub use python::Python;
 pub use rust::Rust;
 
 macro_rules! impl_lang {
@@ -35,7 +37,7 @@ impl_lang!(Html, language_html);
 impl_lang!(JavaScript, language_javascript);
 impl_lang!(Kotlin, language_kotlin);
 impl_lang!(Lua, language_lua);
-impl_lang!(Python, language_python);
+// impl_lang!(Python, language_python);
 impl_lang!(Swift, language_swift);
 impl_lang!(Tsx, language_tsx);
 impl_lang!(TypeScript, language_typescript);

--- a/crates/cli/src/languages/mod.rs
+++ b/crates/cli/src/languages/mod.rs
@@ -36,7 +36,6 @@ impl_lang!(Html, language_html);
 impl_lang!(JavaScript, language_javascript);
 impl_lang!(Kotlin, language_kotlin);
 impl_lang!(Lua, language_lua);
-// impl_lang!(Python, language_python);
 impl_lang!(Swift, language_swift);
 impl_lang!(Tsx, language_tsx);
 impl_lang!(TypeScript, language_typescript);

--- a/crates/cli/src/languages/python.rs
+++ b/crates/cli/src/languages/python.rs
@@ -1,0 +1,132 @@
+use ast_grep_core::language::{Language, TSLanguage};
+use std::borrow::Cow;
+use tree_sitter_python::language as language_python;
+
+// impl_lang!(Python, language_python);
+#[derive(Clone, Copy)]
+pub struct Python;
+impl Language for Python {
+  fn get_ts_language(&self) -> TSLanguage {
+    TSLanguage::from(language_python())
+  }
+  // we can use any char in unicode range [:XID_Start:]
+  // https://docs.python.org/3/reference/lexical_analysis.html#identifiers
+  // see also [PEP 3131](https://peps.python.org/pep-3131/) for further details.
+  fn expando_char(&self) -> char {
+    'µ'
+  }
+  fn pre_process_pattern<'q>(&self, query: &'q str) -> Cow<'q, str> {
+    // use stack buffer to reduce allocation
+    let mut buf = [0; 4];
+    let expando = self.expando_char().encode_utf8(&mut buf);
+    // TODO: use more precise replacement
+    let replaced = query.replace(self.meta_var_char(), expando);
+    Cow::Owned(replaced)
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+  use ast_grep_core::{Matcher, Pattern};
+
+  fn test_match(s1: &str, s2: &str) {
+    let pattern = Pattern::new(s1, Python);
+    let cand = Python.ast_grep(s2);
+    assert!(
+      pattern.find_node(cand.root()).is_some(),
+      "goal: {}, candidate: {}",
+      pattern.root.root().to_sexp(),
+      cand.root().to_sexp(),
+    );
+  }
+
+  #[test]
+  fn test_python_pattern() {
+    test_match("$A = 0", "a = 0");
+    // A test case from https://peps.python.org/pep-0636/#appendix-a-quick-intro
+    test_match(
+      r#"
+match $A:
+    case $B:
+        $C
+    case [$D(0, 0)]:
+        $E
+    case [$D($F, $G)]:
+        $H
+    case [$D(0, $I), $D(0, $J)]:
+        $K
+    case _:
+        $L
+"#,
+      r#"
+match points:
+    case []:
+        print("No points")
+    case [Point(0, 0)]:
+        print("The origin")
+    case [Point(x, y)]:
+        print(f"Single point {x}, {y}")
+    case [Point(0, y1), Point(0, y2)]:
+        print(f"Two on the Y axis at {y1}, {y2}")
+    case _:
+        print("Something else")
+"#,
+    );
+  }
+
+  fn test_replace(src: &str, pattern: &str, replacer: &str) -> String {
+    let mut source = Python.ast_grep(src);
+    let replacer = Pattern::new(replacer, Python);
+    assert!(source.replace(pattern, replacer));
+    source.generate()
+  }
+
+  #[test]
+  fn test_python_replace() {
+    let ret = test_replace(
+      r#"
+if flag:
+    a = value_pos
+else:
+    a = value_neg"#,
+      r#"
+if $FLAG:
+    $VAR = $POS
+else:
+    $VAR = $NEG
+"#,
+      "$VAR = $POS if $FLAG else $NEG",
+    );
+    assert_eq!(ret, "\na = value_pos if flag else value_neg");
+
+    let ret = test_replace(
+      r#"
+try:
+    f = open(file_path, "r")
+    file_content = f.read()
+except:
+    pass
+finally:
+    f.close()"#,
+      r#"
+try:
+    $A = open($B, $C)
+    $D = $A.read()
+except:
+    pass
+finally:
+    $A.close()"#,
+      r#"
+with open($B, $C) as $A:
+    $D = $A.open()"#,
+    );
+    assert_eq!(
+      ret,
+      r#"
+
+with open(file_path, "r") as f:
+    file_content = f.open()"#
+    );
+  }
+}


### PR DESCRIPTION
Thanks for the useful tool, but currently `--lang=py` doesn't work. \_(:з」∠)\_

Since `$` is not a valid identifier in Python (https://docs.python.org/3/reference/lexical_analysis.html#identifiers), I have re-implemented the language `Python` with reference to the csharp implementation (9a14a4b71cc348274ad6d153fc9011aedf9b490e). (・ω< )★